### PR TITLE
Add support for using the modularized passagemath distributions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 Yet Another Cohomology Program
 
+## Installation in Python (no prior installation of SageMath required)
+
+```bash
+pip install "git+https://github.com/passagemath/passagemath-pkg-yacop.git[passagemath]"
+```
+
 ## Docker quickstart
 
 ### Basic invocation

--- a/_doctest_environment.py
+++ b/_doctest_environment.py
@@ -1,0 +1,3 @@
+# Toplevel for doctesting with passagemath
+
+from sage.all__sagemath_modules import *

--- a/setup.py
+++ b/setup.py
@@ -23,4 +23,11 @@ setup(
   url = "http://nullhomotopie.de",
   description = "Yacop - Steenrod algebra cohomology",
   packages=["yacop","yacop.resolutions","yacop.modules","yacop.categories","yacop.utils","yacop.testing"],
+  extras_require={
+      'passagemath': [
+          'passagemath-combinat',
+          'passagemath-modules',
+          'passagemath-repl',
+      ],
+  },
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,22 @@
+[tox]
+envlist = passagemath
+
+[testenv:.pkg]
+passenv =
+    CPATH
+    LIBRARY_PATH
+
+[testenv:passagemath]
+usedevelop = True
+extras = passagemath
+
+passenv =
+    CPATH
+    LIBRARY_PATH
+
+setenv =
+    # For access to _doctest_environment.py
+    PYTHONPATH=.
+
+commands =
+    sage -tp --force-lib --environment=_doctest_environment yacop

--- a/yacop/categories/bimodules.py
+++ b/yacop/categories/bimodules.py
@@ -34,7 +34,7 @@ class YacopBimodules(CategoryWithParameters):
         self._left_base_ring = left_base
         self._right_base_ring = left_base if right_base is None else right_base
         assert self._left_base_ring.characteristic() == self._right_base_ring.characteristic()
-        Category.__init__(self, name)
+        super().__init__()
 
     def _make_named_class_key(self, name):
         return tuple(self.super_categories())
@@ -111,7 +111,7 @@ class YacopBimoduleAlgebras(CategoryWithParameters):
         self._left_base_ring = left_base
         self._right_base_ring = left_base if right_base is None else right_base
         assert self._left_base_ring.characteristic() == self._right_base_ring.characteristic()
-        Category.__init__(self, name)
+        super().__init__()
 
     def _make_named_class_key(self, name):
         return tuple(self.super_categories())

--- a/yacop/modules/algebra_base.py
+++ b/yacop/modules/algebra_base.py
@@ -158,7 +158,7 @@ from sage.sets.family import LazyFamily, Family
 from sage.categories.examples.infinite_enumerated_sets import NonNegativeIntegers
 from sage.categories.algebras_with_basis import AlgebrasWithBasis
 from sage.sets.integer_range import IntegerRange
-from sage.algebras.all import SteenrodAlgebra, Sq
+from sage.algebras.steenrod.all import SteenrodAlgebra, Sq
 from sage.rings.integer import Integer
 from sage.structure.element import have_same_parent
 from sage.structure.formal_sum import FormalSum, FormalSums

--- a/yacop/modules/classifying_spaces.py
+++ b/yacop/modules/classifying_spaces.py
@@ -67,7 +67,7 @@ from yacop.categories import YacopLeftModuleAlgebras
 from sage.rings.infinity import Infinity
 from sage.sets.set import Set
 from sage.sets.integer_range import IntegerRange
-from sage.algebras.all import SteenrodAlgebra
+from sage.algebras.steenrod.all import SteenrodAlgebra
 from sage.rings.integer import Integer
 from sage.structure.unique_representation import UniqueRepresentation
 from sage.arith.misc import is_prime

--- a/yacop/modules/classifying_spaces.py
+++ b/yacop/modules/classifying_spaces.py
@@ -78,7 +78,7 @@ r"""
 
     TESTS::
 
-        sage: from yacop.categories * import YacopLeftModules
+        sage: from yacop.categories import YacopLeftModules
         sage: from yacop.modules.classifying_spaces import *
         sage: TestSuite(BZp(3,prime=3)).run()
         sage: BZp(3) in YacopLeftModules(SteenrodAlgebra(3,profile=((1,),(2,2))))

--- a/yacop/modules/dickson.py
+++ b/yacop/modules/dickson.py
@@ -50,7 +50,7 @@ from sage.categories.examples.infinite_enumerated_sets import NonNegativeInteger
 from sage.categories.algebras_with_basis import AlgebrasWithBasis
 from sage.categories.cartesian_product import cartesian_product
 from sage.sets.integer_range import IntegerRange
-from sage.algebras.all import SteenrodAlgebra, Sq
+from sage.algebras.steenrod.all import SteenrodAlgebra, Sq
 from sage.rings.integer import Integer
 from sage.structure.formal_sum import FormalSum, FormalSums
 from sage.structure.unique_representation import UniqueRepresentation

--- a/yacop/modules/dual_steenrod_algebra.py
+++ b/yacop/modules/dual_steenrod_algebra.py
@@ -16,7 +16,7 @@ from yacop.utils.region import region
 from yacop.modules.algebra_base import SteenrodAlgebraBase
 from sage.rings.infinity import Infinity
 from sage.structure.sage_object import SageObject
-from sage.algebras.all import SteenrodAlgebra
+from sage.algebras.steenrod.all import SteenrodAlgebra
 from yacop.modules.xitauring import XiTauRing
 
 """

--- a/yacop/modules/module_base.py
+++ b/yacop/modules/module_base.py
@@ -29,7 +29,7 @@ from sage.categories.algebras_with_basis import AlgebrasWithBasis
 from sage.categories.enumerated_sets import EnumeratedSets
 from sage.categories.finite_enumerated_sets import FiniteEnumeratedSets
 from sage.sets.integer_range import IntegerRange
-from sage.algebras.all import SteenrodAlgebra, Sq
+from sage.algebras.steenrod.all import SteenrodAlgebra, Sq
 from sage.rings.integer import Integer
 from sage.structure.formal_sum import FormalSum, FormalSums
 from sage.structure.unique_representation import UniqueRepresentation

--- a/yacop/modules/morph_module.py
+++ b/yacop/modules/morph_module.py
@@ -29,7 +29,7 @@ from sage.categories.algebras_with_basis import AlgebrasWithBasis
 from sage.categories.enumerated_sets import EnumeratedSets
 from sage.categories.finite_enumerated_sets import FiniteEnumeratedSets
 from sage.sets.integer_range import IntegerRange
-from sage.algebras.all import SteenrodAlgebra, Sq
+from sage.algebras.steenrod.all import SteenrodAlgebra, Sq
 from sage.rings.integer import Integer
 from sage.structure.formal_sum import FormalSum, FormalSums
 from sage.structure.unique_representation import UniqueRepresentation

--- a/yacop/modules/projective_spaces.py
+++ b/yacop/modules/projective_spaces.py
@@ -115,7 +115,7 @@ from yacop.categories import YacopLeftModuleAlgebras
 from sage.rings.infinity import Infinity
 from sage.sets.set import Set
 from sage.sets.integer_range import IntegerRange
-from sage.algebras.all import SteenrodAlgebra
+from sage.algebras.steenrod.all import SteenrodAlgebra
 from sage.rings.integer import Integer
 from sage.structure.unique_representation import UniqueRepresentation
 from yacop.utils.finite_graded_set import InfiniteGradedSet

--- a/yacop/modules/serre_cartan.py
+++ b/yacop/modules/serre_cartan.py
@@ -84,7 +84,7 @@ CLASS DOCUMENTATION:
 #       Copyright (C) 2011 Christian Nassau <nassau@nullhomotopie.de>
 #  Distributed under the terms of the GNU General Public License (GPL)
 # *****************************************************************************
-from sage.algebras.all import SteenrodAlgebra, Sq
+from sage.algebras.steenrod.all import SteenrodAlgebra, Sq
 from sage.misc.cachefunc import cached_method
 from yacop.categories import YacopLeftModules
 from yacop.utils.gradings import YacopGradingFromDict

--- a/yacop/modules/xitauring.py
+++ b/yacop/modules/xitauring.py
@@ -28,7 +28,7 @@ from sage.categories.examples.infinite_enumerated_sets import NonNegativeInteger
 from sage.categories.algebras_with_basis import AlgebrasWithBasis
 from sage.categories.cartesian_product import cartesian_product
 from sage.sets.integer_range import IntegerRange
-from sage.algebras.all import SteenrodAlgebra, Sq
+from sage.algebras.steenrod.all import SteenrodAlgebra, Sq
 from sage.rings.integer import Integer
 from sage.structure.formal_sum import FormalSum, FormalSums
 from sage.structure.unique_representation import UniqueRepresentation

--- a/yacop/resolutions/minres.py
+++ b/yacop/resolutions/minres.py
@@ -46,7 +46,7 @@ from sage.categories.enumerated_sets import EnumeratedSets
 from sage.categories.finite_enumerated_sets import FiniteEnumeratedSets
 from sage.categories.sets_cat import Sets
 from sage.sets.integer_range import IntegerRange
-from sage.algebras.all import SteenrodAlgebra, Sq
+from sage.algebras.steenrod.all import SteenrodAlgebra, Sq
 from sage.rings.integer import Integer
 from sage.structure.formal_sum import FormalSum, FormalSums
 from sage.misc.cachefunc import cached_method

--- a/yacop/utils/gradings.py
+++ b/yacop/utils/gradings.py
@@ -16,7 +16,7 @@ We use :meth:`YacopGrading` objects to represent such a grading::
    sage: dct.append((region(t=1,e=0,s=3),(1,2,3)))
    sage: dct.append((region(t=2,e=1,s=1),(4,)))
    sage: dct.append((region(t=0,e=7,s=1),(5,6)))
-   sage: G = YacopGradingFromDict(dct) ; G.__custom_name = "G" ; G
+   sage: G = YacopGradingFromDict(dct) ; G.rename("G") ; G
    G
    sage: G.bbox()
    region(0 <= e <= 7, 1 <= s <= 3, 0 <= t <= 2)
@@ -71,7 +71,7 @@ CARTESIAN PRODUCTS::
    sage: dct.append((region(t=1,e=0,s=3),(7)))
    sage: dct.append((region(t=2,e=1,s=1),(8,9)))
    sage: dct.append((region(t=-1,e=4,s=1),(10,11)))
-   sage: H = YacopGradingFromDict(dct) ; H.__custom_name = "H"
+   sage: H = YacopGradingFromDict(dct) ; H.rename("H")
    sage: T = cartesian_product([G,H]) ; T
    G (+) H
    sage: G.bbox()

--- a/yacop/utils/startup.py
+++ b/yacop/utils/startup.py
@@ -97,7 +97,10 @@ def __startup__():
     def __copy__(self):
         return self
 
-    AbstractFamily.__copy__ = __copy__
+    try:
+        AbstractFamily.__copy__ = __copy__
+    except TypeError:  # cython class
+        pass
 
     # LazyFamilies cannot be pickled... turn off the resulting noise
     def _test_pickling(self, tester=None, **options):


### PR DESCRIPTION
To test, use `tox`. There are numerous doctest failures - likely from general bitrot over the years